### PR TITLE
Session-aware runtime reset, restart/lock UI, and safer state initialization for game sessions

### DIFF
--- a/src/ClientApp/src/features/game-arena-page/components/ArenaCard.tsx
+++ b/src/ClientApp/src/features/game-arena-page/components/ArenaCard.tsx
@@ -1,6 +1,6 @@
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Info, SwordsIcon } from "lucide-react"
+import { Info, RotateCcw, SwordsIcon } from "lucide-react"
 import { Game } from "@/features/game/Game"
 import { useArenaStore } from "@/features/game/state/data/arena.data.store"
 import { Skeleton } from "@/components/ui/skeleton"
@@ -15,10 +15,13 @@ import { useViewportStore } from "@/features/game/state/viewport/viewport.store"
 import { useGridStore } from "@/features/game/state/game/grid.state.store"
 import { Switch } from "@/components/ui/switch"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
+import { useGameRuntimeStore } from "@/features/game/state/game.runtime.store"
+import { isGameSessionActive } from "@/features/game/types/GameSession"
+import { resetGameWorldState } from "@/features/game/state/stateReset"
 
 export function ArenaCard() {
   const navigate = useNavigate()
-  const { modeType, arenaId } = useParams<{ modeType: string; arenaId: string }>()
+  const { modeType, arenaId, sessionId } = useParams<{ modeType: string; arenaId: string; sessionId?: string }>()
 
   const setViewportSize = useViewportStore(s => s.setSize)
   const { showGrid, setShowGrid } = useGridStore()
@@ -29,19 +32,15 @@ export function ArenaCard() {
 
   const arena = useArenaStore(s => s.arena)
   const character = useCharacterStore(s => s.character)
+  const session = useGameRuntimeStore(s => s.session)
   const getActiveCode = useCodeEditorStore(s => s.getActiveCode)
   const { start: startLoading, isLoading } = useGameBootstrapStore()
 
   const { mutateAsync: startGame } = useStartGame()
 
-  async function handleStart() {
+  async function startSession(characterId: string) {
     if (!arenaId) {
       toast.error("Арена не выбрана")
-      return
-    }
-
-    if (!character) {
-      toast.error("Персонаж не выбран")
       return
     }
 
@@ -56,21 +55,45 @@ export function ArenaCard() {
       return
     }
 
+    resetGameWorldState()
     startLoading()
 
-    const sessionId = await startGame({
+    const newSessionId = await startGame({
       arenaId,
       mode: modeType,
-      characterId: character.id,
+      characterId,
       code: localCode.sourceCode
     })
 
-    navigate(`/play/${modeType}/${arenaId}/${sessionId}`)
+    navigate(`/play/${modeType}/${arenaId}/${newSessionId}`)
+  }
+
+  async function handleStart() {
+    if (!character) {
+      toast.error("Персонаж не выбран")
+      return
+    }
+
+    await startSession(character.id)
+  }
+
+  async function handleRestart() {
+    const restartCharacterId = session?.characterId ?? character?.id
+
+    if (!restartCharacterId) {
+      toast.error("Персонаж не выбран")
+      return
+    }
+
+    await startSession(restartCharacterId)
   }
 
   if (!arena) {
     return <Skeleton className="w-full h-full rounded-none md:rounded-r-2xl" />
   }
+
+  const isSessionActive = isGameSessionActive(session)
+  const canRestart = Boolean(sessionId && session && !isSessionActive)
 
   return (
     <Card className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -117,9 +140,17 @@ export function ArenaCard() {
           </span>
         </div>
 
-        <Button size="lg" disabled={isLoading} onClick={handleStart}>
-          {isLoading ? "Готовимся к бою..." : <><SwordsIcon /> В бой</>}
-        </Button>
+        <div className="flex items-center gap-2">
+          {canRestart && (
+            <Button size="lg" variant="outline" disabled={isLoading} onClick={handleRestart}>
+              <RotateCcw /> Повторить бой
+            </Button>
+          )}
+
+          <Button size="lg" disabled={isLoading || isSessionActive} onClick={handleStart}>
+            {isLoading ? "Готовимся к бою..." : <><SwordsIcon /> В бой</>}
+          </Button>
+        </div>
       </CardFooter>
     </Card>
   )

--- a/src/ClientApp/src/features/game-arena-page/components/SelectCharacterCard.tsx
+++ b/src/ClientApp/src/features/game-arena-page/components/SelectCharacterCard.tsx
@@ -20,13 +20,19 @@ import { SpriteAnimationPlayer } from "@/features/character-class-selector/compo
 import { CharacterStats } from "@/features/character-class-selector/components/CharacterStats"
 import { StatType } from "@/shared/types/stat"
 import { useArenaStore } from "@/features/game/state/data/arena.data.store"
+import { useGameRuntimeStore } from "@/features/game/state/game.runtime.store"
+import { isGameSessionActive } from "@/features/game/types/GameSession"
 
 export function SelectCharacterCard() {
   const arena = useArenaStore(s => s.arena)
+  const session = useGameRuntimeStore(s => s.session)
+  const runtimeVersion = useGameRuntimeStore(s => s.runtimeVersion)
   const { data: characters, isLoading, error } = useCharacters()
   const [selectedCharacterId, setSelectedCharacterId] = useState<string | undefined>()
   const { data: character } = useCharacterDetails(selectedCharacterId)
   const init = useCharacterStateStore(s => s.init)
+
+  const isCharacterLocked = isGameSessionActive(session)
 
   useEffect(() => {
     if (!character || !arena) return
@@ -35,7 +41,21 @@ export function SelectCharacterCard() {
     const mana = character.class.stats.find(s => s.statType === StatType.Mana)?.value
     init({ characterId: character.id, maxHp: health ?? 0, maxMp: mana, startPosition: arena.startPosition })
 
-  }, [character?.id, arena?.startPosition])
+  }, [character?.id, arena?.startPosition, runtimeVersion, init])
+
+  useEffect(() => {
+    if (!characters?.length) return
+
+    if (session?.characterId) {
+      const exists = characters.some(c => c.id === session.characterId)
+      if (exists) {
+        setSelectedCharacterId(session.characterId)
+        return
+      }
+    }
+
+    setSelectedCharacterId(prev => prev ?? characters[0]?.id)
+  }, [characters, session?.characterId])
 
   const handleCreateClick = () => {
     window.open("/characters/create", "_blank")
@@ -58,6 +78,7 @@ export function SelectCharacterCard() {
               <Select
                 value={selectedCharacterId}
                 onValueChange={setSelectedCharacterId}
+                disabled={isCharacterLocked}
               >
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Выберите персонажа" />
@@ -88,12 +109,10 @@ export function SelectCharacterCard() {
 
           {character && (
             <>
-              {/* Левая часть — спрайт */}
               <div className="flex items-center justify-center p-4">
                 <SpriteAnimationPlayer actionAssets={character.class.actionAssets} />
               </div>
 
-              {/* Правая часть — характеристики */}
               <CharacterStats stats={character.class.stats} />
             </>
           )}

--- a/src/ClientApp/src/features/game-arena-page/hooks/useGameSession.ts
+++ b/src/ClientApp/src/features/game-arena-page/hooks/useGameSession.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { gameHub } from "@/features/game/api/gameHub"
 import { useGameRuntimeStore } from "@/features/game/state/game.runtime.store"
 import { resetGameStores } from "@/features/game/state/stateReset"
@@ -10,13 +10,15 @@ import { useGameBootstrapStore } from "@/features/game/state/game.bootstrap.stor
 import type { TurnLog } from "@/features/game/types/TurnLog"
 
 export function useGameSession(sessionId?: string) {
-  const { setSession, setTurnLogs } = useGameRuntimeStore()
+  const prevSessionId = useRef<string | undefined>(undefined)
+  const { setSession, replaceTurnLogs, reset } = useGameRuntimeStore()
 
   const { data: session, isLoading } = useQuery<GameSession, ApiException>({
     queryKey: queryKeys.gameSessions.byId(sessionId),
     queryFn: () => apiFetch(`/game/sessions/${sessionId}`),
     enabled: !!sessionId,
     retry: false,
+    refetchOnMount: "always"
   })
 
   const { data: logs } = useQuery<TurnLog[], ApiException>({
@@ -24,6 +26,7 @@ export function useGameSession(sessionId?: string) {
     queryFn: () => apiFetch(`/game/sessions/${sessionId}/logs`),
     enabled: !!sessionId,
     retry: false,
+    refetchOnMount: "always"
   })
 
   useEffect(() => {
@@ -39,14 +42,29 @@ export function useGameSession(sessionId?: string) {
   }, [])
 
   useEffect(() => {
-    if (!session) return
-    setSession(session)
-  }, [session, setSession])
+    if (prevSessionId.current === sessionId) return
+
+    reset()
+    prevSessionId.current = sessionId
+
+    if (!sessionId) {
+      useGameBootstrapStore.getState().end()
+    }
+  }, [sessionId, reset])
 
   useEffect(() => {
-    if (!logs?.length) return
-    setTurnLogs(logs)
-  }, [logs, setTurnLogs])
+    if (!sessionId || !session) return
+    setSession(session)
+  }, [sessionId, session, setSession])
+
+  useEffect(() => {
+    if (!sessionId) {
+      replaceTurnLogs([])
+      return
+    }
+
+    replaceTurnLogs(logs ?? [])
+  }, [sessionId, logs, replaceTurnLogs])
 
   const isActive = session ? isGameSessionActive(session) : false
 

--- a/src/ClientApp/src/features/game/arena-enemies/ArenaEnemies.tsx
+++ b/src/ClientApp/src/features/game/arena-enemies/ArenaEnemies.tsx
@@ -5,11 +5,13 @@ import { useArenaEnemies } from "./useArenaEnemies"
 import { fetchEnemy } from "./fetchEnemy"
 import { useEnemyStateStore } from "../state/game/enemy.state.store"
 import { StatType } from "@/shared/types/stat"
+import { useGameRuntimeStore } from "../state/game.runtime.store"
 
 export function ArenaEnemies() {
   const { data: arenaEnemies } = useArenaEnemies()
   const setEnemies = useEnemiesStore(s => s.setEnemies)
   const init = useEnemyStateStore(s => s.init)
+  const runtimeVersion = useGameRuntimeStore(s => s.runtimeVersion)
 
   useEffect(() => {
     if (!arenaEnemies) return
@@ -37,7 +39,7 @@ export function ArenaEnemies() {
         init(initPayload)
       })
       .catch(console.error)
-  }, [arenaEnemies])
+  }, [arenaEnemies, runtimeVersion, setEnemies, init])
 
   if (!arenaEnemies)
     return null

--- a/src/ClientApp/src/features/game/state/game.runtime.store.ts
+++ b/src/ClientApp/src/features/game/state/game.runtime.store.ts
@@ -5,12 +5,14 @@ import { playRuntimeLog } from "../runtime/playRuntimeLog";
 
 interface GameRuntimeState {
   session: GameSession | null;
-  setSession: (session: GameSession) => void;
+  setSession: (session: GameSession | null) => void;
   turnLogs: TurnLog[]
   setTurnLogs: (turnLogs: TurnLog[]) => void;
+  replaceTurnLogs: (turnLogs: TurnLog[]) => void;
 
   queue: TurnLog[];
   isProcessing: boolean;
+  runtimeVersion: number;
   enqueueTurn: (turnLog: TurnLog) => void;
   processNext: () => Promise<void>;
   reset: () => void;
@@ -55,8 +57,11 @@ export const useGameRuntimeStore = create<GameRuntimeState>((set, get) => ({
     })
   },
 
+  replaceTurnLogs: (turnLogs) => set({ turnLogs }),
+
   queue: [],
   isProcessing: false,
+  runtimeVersion: 0,
 
   enqueueTurn: (turnLog) => {
     set((state) => ({
@@ -72,10 +77,15 @@ export const useGameRuntimeStore = create<GameRuntimeState>((set, get) => ({
     const turn = get().queue[0];
     if (!turn) return;
 
+    const currentRuntimeVersion = get().runtimeVersion
     set({ isProcessing: true });
 
     for (const entry of turn.logs) {
-      // добавляем лог в стор по одному
+      if (get().runtimeVersion !== currentRuntimeVersion) {
+        set({ isProcessing: false })
+        return
+      }
+
       set((state) => {
         const turns = [...state.turnLogs]
         let targetTurn = turns.find(t => t.turnIndex === entry.turnIndex)
@@ -97,20 +107,25 @@ export const useGameRuntimeStore = create<GameRuntimeState>((set, get) => ({
       await playRuntimeLog(entry);
     }
 
+    if (get().runtimeVersion !== currentRuntimeVersion) {
+      set({ isProcessing: false })
+      return
+    }
+
     set((s) => ({
       queue: s.queue.slice(1),
       isProcessing: false,
     }));
 
-    // гарантированная последовательность
     queueMicrotask(() => get().processNext());
   },
 
   reset: () =>
-    set({
+    set((state) => ({
       session: null,
       turnLogs: [],
       queue: [],
       isProcessing: false,
-    }),
+      runtimeVersion: state.runtimeVersion + 1,
+    })),
 }));

--- a/src/ClientApp/src/features/game/state/game/character.state.store.ts
+++ b/src/ClientApp/src/features/game/state/game/character.state.store.ts
@@ -21,19 +21,16 @@ export const useCharacterStateStore = create<CharacterRuntimeState>((set, get) =
   runtime: undefined,
 
   init: (payload) => {
-    const prev = get().runtime
-    if (!prev || prev.id !== payload.characterId) {
-      set({
-        runtime: {
-          id: payload.characterId,
-          action: ActionType.Idle,
-          hp: { current: payload.maxHp, max: payload.maxHp },
-          mp: payload.maxMp ? { current: payload.maxMp, max: payload.maxMp } : undefined,
-          facing: FacingDirection.Right,
-          position: payload.startPosition,
-        },
-      })
-    }
+    set({
+      runtime: {
+        id: payload.characterId,
+        action: ActionType.Idle,
+        hp: { current: payload.maxHp, max: payload.maxHp },
+        mp: payload.maxMp ? { current: payload.maxMp, max: payload.maxMp } : undefined,
+        facing: FacingDirection.Right,
+        position: payload.startPosition,
+      },
+    })
   },
 
   set: (runtime) => {

--- a/src/ClientApp/src/features/game/state/game/enemy.state.store.ts
+++ b/src/ClientApp/src/features/game/state/game/enemy.state.store.ts
@@ -23,12 +23,10 @@ export const useEnemyStateStore = create<EnemyRuntimeStore>((set, get) => ({
   arenaEnemies: {},
 
   init: (arenaEnemies) => {
-    const current = get().arenaEnemies
-    const updated = { ...current }
+    const next: Record<string, UnitRuntime> = {}
 
     for (const { arenaEnemyId, position, maxHp, maxMp } of arenaEnemies) {
-      if (updated[arenaEnemyId]) continue
-      updated[arenaEnemyId] = {
+      next[arenaEnemyId] = {
         id: arenaEnemyId,
         action: ActionType.Idle,
         hp: { current: maxHp, max: maxHp },
@@ -38,7 +36,7 @@ export const useEnemyStateStore = create<EnemyRuntimeStore>((set, get) => ({
       }
     }
 
-    set({ arenaEnemies: updated })
+    set({ arenaEnemies: next })
   },
 
   set: (arenaEnemyId, partial) => {

--- a/src/ClientApp/src/features/game/state/stateReset.ts
+++ b/src/ClientApp/src/features/game/state/stateReset.ts
@@ -16,11 +16,15 @@ export function resetGameStores() {
   useEnemiesStore.getState().reset()
   useTexturesStore.getState().reset()
 
+  resetGameWorldState()
+}
+
+export function resetGameWorldState() {
+
   useCharacterStateStore.getState().reset()
   useEnemyStateStore.getState().reset()
   useGridStore.getState().reset()
 
   useGameRuntimeStore.getState().reset()
   useGameBootstrapStore.getState().end()
-
 }


### PR DESCRIPTION
### Motivation
- Allow restarting a finished session and prevent starting a new session while an active session is running by making runtime/session state explicit and abortable. 
- Ensure runtime stores and queued log processing are reset cleanly when switching sessions to avoid stale state or race conditions. 
- Pre-select and lock the character selection when a session exists so the UI reflects the current session state.

### Description
- Added session-aware start/restart flow in `ArenaCard`: introduced `startSession`, `handleRestart`, `sessionId` handling, `resetGameWorldState()` before starting, disabled start while session is active, and added a restart button with `RotateCcw` icon. 
- Made character selection session-aware in `SelectCharacterCard`: auto-selects character from runtime `session`, disables the `Select` when a session is active, and depends on `runtimeVersion` for re-initialization. 
- Strengthened session lifecycle in `useGameSession`: added `prevSessionId` tracking, always refetch data on mount, reset runtime on sessionId change, replace logs instead of merging on session changes, and start/stop the bootstrap loader appropriately. 
- Implemented abortable runtime processing in `game.runtime.store`: added `runtimeVersion` and `replaceTurnLogs`, bumped `runtimeVersion` on `reset`, and made `processNext` abort if `runtimeVersion` changes during processing. 
- Simplified and made deterministic state initialization for in-game units: `character.state.store` now always re-initializes the character runtime, and `enemy.state.store` builds a fresh mapping (replacing merging behavior). 
- Consolidated reset helpers in `stateReset.ts`: separated `resetGameStores` and `resetGameWorldState` and ensured runtime stores and bootstrap are cleared on reset. 
- Added `runtimeVersion` dependencies where needed (`ArenaEnemies`, `SelectCharacterCard`) so components re-init when the runtime resets.

### Testing
- Ran a TypeScript build with `yarn build` and it completed successfully. 
- Executed unit tests with `yarn test` and all tests passed. 
- Ran linting with `yarn lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6888a9950832d80f2dd2829d061d0)