### PR TITLE
Add Portainer/docker-compose production stack, env template, Dockerfiles and client API helpers

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 **/.classpath
-**/.dockerignore
 **/.env
 **/.git
 **/.gitignore
@@ -13,13 +12,12 @@
 **/*.jfm
 **/azds.yaml
 **/bin
+**/.containers
 **/charts
-**/docker-compose*
-**/Dockerfile*
 **/node_modules
 **/npm-debug.log
 **/obj
 **/secrets.dev.yaml
 **/values.dev.yaml
-LICENSE
-README.md
+.env
+.git/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,45 @@
+# Copy this file to .env before deploying the stack in Portainer.
+
+# Public URLs/ports
+PUBLIC_CLIENT_ORIGIN=http://localhost
+CLIENT_API_URL=/api
+CLIENT_GAME_HUB_URL=/game-runtime-hub
+CLIENT_PORT=80
+WEB_API_PORT=5000
+POSTGRES_PORT=5432
+MINIO_API_PORT=9000
+MINIO_CONSOLE_PORT=9001
+ASPIRE_DASHBOARD_PORT=18888
+ASPIRE_DASHBOARD_OTLP_GRPC_PORT=4317
+ASPIRE_DASHBOARD_OTLP_HTTP_PORT=4318
+
+# PostgreSQL
+POSTGRES_DB=bytefight
+POSTGRES_USER=bytefight
+POSTGRES_PASSWORD=change-me-postgres-password
+
+# MinIO
+MINIO_ROOT_USER=bytefight-minio-admin
+MINIO_ROOT_PASSWORD=change-me-minio-password
+MINIO_BUCKET_NAME=assets
+
+# JWT: use a long random value, at least 32 bytes.
+JWT_SECRET=change-me-to-a-long-random-secret-at-least-32-bytes
+JWT_ISSUER=bytefight-api
+JWT_AUDIENCE=bytefight-client
+JWT_EXPIRATION_IN_MINUTES=60
+
+# First deploy can keep both true. After the first successful deploy you may set SEED_ON_STARTUP=false.
+APPLY_MIGRATIONS=true
+SEED_ON_STARTUP=true
+
+# OpenTelemetry resource shown in Aspire Dashboard
+OTEL_SERVICE_NAME=bytefight-web-api
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=bytefight,deployment.environment=production
+
+# Aspire Dashboard
+ASPIRE_DASHBOARD_TAG=latest
+ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=false
+ASPIRE_DASHBOARD_MAX_LOG_COUNT=10000
+ASPIRE_DASHBOARD_MAX_TRACE_COUNT=10000
+ASPIRE_DASHBOARD_MAX_METRICS_COUNT=10000

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [Суть проекта и ключевые особенности](#-суть-проекта-и-ключевые-особенности)
 - [Технологии и архитектура](#-технологии-и-архитектура)
 - [Локальный запуск](#-локальный-запуск-windows)
+- [Подготовка к production и Portainer](#-подготовка-к-production-и-portainer)
 - [Контрибьютинг и обратная связь](#-контрибьютинг-и-обратная-связь)
 - [Планы развития](#-планы-развития)
 - [Лицензия](#-лицензия)
@@ -328,6 +329,96 @@ pnpm build
 - Проверьте установленную версию .NET командой `dotnet --info`
 - При ошибках зависимостей клиента удалите `node_modules` и выполните `pnpm install` повторно
 - При проблемах с запуском Aspire проверьте, что установлены необходимые компоненты Visual Studio и актуальная версия .NET SDK
+
+---
+
+
+## 🚢 Подготовка к production и Portainer
+
+### Что нужно сделать сначала
+
+1. **Определить публичные адреса**: домен клиента, домен/API-путь, способ доступа к MinIO Console и Aspire Dashboard. Для текущего `docker-compose.yml` клиент работает как основной вход, а запросы к API идут через `/api`.
+2. **Подготовить секреты**: скопировать `.env.example` в `.env` и заменить все `change-me-*` значения. Минимально обязательны `POSTGRES_PASSWORD`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, `JWT_SECRET`.
+3. **Решить вопрос TLS**: в production ставьте обратный прокси перед Portainer stack (Traefik, Nginx Proxy Manager, Caddy или внешний балансировщик) и публикуйте наружу только нужные HTTP(S)-точки.
+4. **Загрузить ассеты в MinIO**: после первого запуска создать/проверить bucket `assets` и загрузить файлы из архива ассетов с сохранением структуры.
+5. **Проверить миграции и seed**: первый запуск можно делать с `APPLY_MIGRATIONS=true` и `SEED_ON_STARTUP=true`; после успешного seed обычно стоит выставить `SEED_ON_STARTUP=false`.
+6. **Ограничить доступ к диагностике**: Aspire Dashboard показывает логи, traces, метрики и потенциально чувствительные данные. Не публикуйте его без авторизации/VPN/IP allowlist.
+
+### Состав production stack
+
+В корне репозитория добавлены файлы для Portainer/Docker Compose:
+
+- `docker-compose.yml` — stack из PostgreSQL, MinIO, Web API, React/Nginx клиента и standalone Aspire Dashboard.
+- `.env.example` — шаблон переменных окружения для Portainer stack.
+- `.dockerignore` — исключает `bin`, `obj`, `node_modules`, `.env` и локальные контейнерные данные из Docker build context.
+- `src/Web.Api/Dockerfile` — production-сборка API на .NET 10 с публикацией `user-code-worker`.
+- `src/ClientApp/Dockerfile` и `src/ClientApp/nginx.conf` — production-сборка SPA и reverse proxy для `/api` и `/game-runtime-hub`.
+
+### Быстрый запуск локально через Docker Compose
+
+```bash
+cp .env.example .env
+# Отредактируйте .env: задайте надежные POSTGRES_PASSWORD, MINIO_ROOT_PASSWORD и JWT_SECRET.
+docker compose up -d --build
+```
+
+Адреса по умолчанию:
+
+- Клиент: `http://localhost`
+- API напрямую: `http://localhost:5000`
+- MinIO API: `http://localhost:9000`
+- MinIO Console: `http://localhost:9001`
+- Aspire Dashboard: `http://localhost:18888`
+
+### Развертывание в Portainer
+
+1. Откройте **Stacks → Add stack**.
+2. Выберите репозиторий Git или вставьте содержимое `docker-compose.yml`.
+3. В секции **Environment variables** перенесите значения из `.env.example` и замените секреты.
+4. Нажмите **Deploy the stack**.
+5. После запуска проверьте health endpoint API: `http://<host>:5000/health`.
+6. Зайдите в MinIO Console и загрузите ассеты в bucket `assets`.
+
+### Aspire Dashboard в production
+
+В stack используется standalone dashboard image `mcr.microsoft.com/dotnet/aspire-dashboard`. Web API отправляет телеметрию через OTLP/gRPC:
+
+```text
+OTEL_SERVICE_NAME=bytefight-web-api
+OTEL_RESOURCE_ATTRIBUTES=service.namespace=bytefight,deployment.environment=production
+OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+```
+
+Dashboard UI доступен на порту `ASPIRE_DASHBOARD_PORT` (по умолчанию `18888`). По умолчанию `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=false`, поэтому токен входа нужно взять из логов контейнера `aspire-dashboard` в Portainer. Для локальной разработки можно временно поставить `ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true`, но для публичного production так делать нельзя.
+
+В compose dashboard явно слушает `0.0.0.0:18888`, `0.0.0.0:18889` и `0.0.0.0:18890`, чтобы OTLP был доступен не только внутри самого контейнера dashboard, но и из контейнера `web-api` по DNS-имени `aspire-dashboard`.
+
+Если в dashboard не появляются метрики/логи/traces:
+
+1. Проверьте, что в `web-api` реально есть переменные `OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889` и `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`.
+2. Проверьте логи `web-api`: ошибки вида `Unavailable`, `connection refused`, `Name or service not known` указывают на проблему DNS/порта/доступности dashboard.
+3. Проверьте логи `aspire-dashboard`: должен быть endpoint OTLP/gRPC на `18889`; при включенной авторизации frontend токен входа также будет в этих логах.
+4. Сделайте несколько HTTP-запросов в API и подождите до минуты: метрики экспортируются периодически, а не синхронно с каждым запросом.
+5. В standalone dashboard список Aspire resources может быть пустым без resource service, но telemetry pages должны показывать сервис `bytefight-web-api`.
+
+> Важно: standalone Aspire Dashboard хранит телеметрию в памяти и предназначен для разработки/краткосрочной диагностики. Для долгосрочного production-monitoring дополнительно планируйте постоянное хранилище логов/метрик (например, Grafana stack, Seq, Azure Monitor и т.п.).
+
+### Production-настройки приложения
+
+- `Database:ApplyMigrations` и `Database:SeedOnStartup` теперь можно включать через переменные `Database__ApplyMigrations` и `Database__SeedOnStartup` без перевода приложения в `Development`.
+- CORS настраивается через `Cors__AllowedOrigins__0`, `Cors__AllowedOrigins__1` и т.д. При размещении клиента и API за одним Nginx (`/api`) CORS почти не используется, но настройка оставлена для отдельных доменов.
+- `src/ClientApp/.env.production` использует `VITE_API_URL=/api` и `VITE_GAME_HUB_URL=/game-runtime-hub`; Nginx в клиентском контейнере проксирует `/api/*` в Web API с удалением префикса `/api`, а SignalR идет через отдельный WebSocket location.
+- Значения `CLIENT_API_URL` и `CLIENT_GAME_HUB_URL` попадают в Vite на этапе сборки клиентского Docker image. Если меняете публичную схему маршрутизации, пересоберите контейнер клиента.
+
+### Что еще нужно перед реальным публичным запуском
+
+- Заменить все дефолтные пароли и `JWT_SECRET` на секреты из password manager/Portainer secrets.
+- Настроить TLS и безопасные cookies/headers на внешнем reverse proxy.
+- Закрыть прямые порты PostgreSQL и MinIO API снаружи, если они не нужны публично.
+- Настроить backup volumes `postgres-data` и `minio-data`.
+- Проверить политику выполнения пользовательского кода и лимиты ресурсов контейнера `web-api`.
+- Прогнать `dotnet test ByteFight.sln` и `pnpm build` перед публикацией образов.
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,90 @@
+services:
+  postgres:
+    image: postgres:17
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-bytefight}
+      POSTGRES_USER: ${POSTGRES_USER:-bytefight}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?Set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?Set MINIO_ROOT_PASSWORD in .env}
+    volumes:
+      - minio-data:/data
+    ports:
+      - "${MINIO_API_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+
+  aspire-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:${ASPIRE_DASHBOARD_TAG:-latest}
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_URLS: http://0.0.0.0:18888
+      ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL: http://0.0.0.0:18889
+      ASPIRE_DASHBOARD_OTLP_HTTP_ENDPOINT_URL: http://0.0.0.0:18890
+      ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS: ${ASPIRE_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS:-false}
+      DASHBOARD__TELEMETRYLIMITS__MAXLOGCOUNT: ${ASPIRE_DASHBOARD_MAX_LOG_COUNT:-10000}
+      DASHBOARD__TELEMETRYLIMITS__MAXTRACECOUNT: ${ASPIRE_DASHBOARD_MAX_TRACE_COUNT:-10000}
+      DASHBOARD__TELEMETRYLIMITS__MAXMETRICSCOUNT: ${ASPIRE_DASHBOARD_MAX_METRICS_COUNT:-10000}
+    ports:
+      - "${ASPIRE_DASHBOARD_PORT:-18888}:18888"
+      - "${ASPIRE_DASHBOARD_OTLP_GRPC_PORT:-4317}:18889"
+      - "${ASPIRE_DASHBOARD_OTLP_HTTP_PORT:-4318}:18890"
+
+  web-api:
+    build:
+      context: .
+      dockerfile: src/Web.Api/Dockerfile
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_URLS: http://+:8080
+      ConnectionStrings__Database: Host=postgres;Port=5432;Database=${POSTGRES_DB:-bytefight};Username=${POSTGRES_USER:-bytefight};Password=${POSTGRES_PASSWORD};Include Error Detail=false
+      Database__ApplyMigrations: ${APPLY_MIGRATIONS:-true}
+      Database__SeedOnStartup: ${SEED_ON_STARTUP:-true}
+      Jwt__Secret: ${JWT_SECRET:?Set JWT_SECRET in .env}
+      Jwt__Issuer: ${JWT_ISSUER:-bytefight-api}
+      Jwt__Audience: ${JWT_AUDIENCE:-bytefight-client}
+      Jwt__ExpirationInMinutes: ${JWT_EXPIRATION_IN_MINUTES:-60}
+      Minio__Endpoint: minio:9000
+      Minio__AccessKey: ${MINIO_ROOT_USER}
+      Minio__SecretKey: ${MINIO_ROOT_PASSWORD}
+      Minio__BucketName: ${MINIO_BUCKET_NAME:-assets}
+      Minio__UseSSL: false
+      Cors__AllowedOrigins__0: ${PUBLIC_CLIENT_ORIGIN:-http://localhost}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-bytefight-web-api}
+      OTEL_RESOURCE_ATTRIBUTES: ${OTEL_RESOURCE_ATTRIBUTES:-service.namespace=bytefight,deployment.environment=production}
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://aspire-dashboard:18889
+      OTEL_EXPORTER_OTLP_PROTOCOL: grpc
+    depends_on:
+      - postgres
+      - minio
+      - aspire-dashboard
+    ports:
+      - "${WEB_API_PORT:-5000}:8080"
+
+  client:
+    build:
+      context: src/ClientApp
+      dockerfile: Dockerfile
+      args:
+        VITE_API_URL: ${CLIENT_API_URL:-/api}
+        VITE_GAME_HUB_URL: ${CLIENT_GAME_HUB_URL:-/game-runtime-hub}
+    restart: unless-stopped
+    depends_on:
+      - web-api
+    ports:
+      - "${CLIENT_PORT:-80}:80"
+
+volumes:
+  postgres-data:
+  minio-data:

--- a/src/Aspire.AppHost/Properties/launchSettings.json
+++ b/src/Aspire.AppHost/Properties/launchSettings.json
@@ -9,8 +9,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21034",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22017"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21034",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22017"
       }
     },
     "http": {
@@ -21,8 +21,8 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "DOTNET_ENVIRONMENT": "Development",
-        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19291",
-        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20183"
+        "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19291",
+        "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20183"
       }
     }
   }

--- a/src/ClientApp/.env.development
+++ b/src/ClientApp/.env.development
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:5000
+VITE_GAME_HUB_URL=/game-runtime-hub

--- a/src/ClientApp/.env.production
+++ b/src/ClientApp/.env.production
@@ -1,1 +1,2 @@
 VITE_API_URL=/api
+VITE_GAME_HUB_URL=/game-runtime-hub

--- a/src/ClientApp/Dockerfile
+++ b/src/ClientApp/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:22-alpine AS build
+WORKDIR /app
+
+RUN corepack enable
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+ARG VITE_API_URL=/api
+ARG VITE_GAME_HUB_URL=/game-runtime-hub
+ENV VITE_API_URL=$VITE_API_URL
+ENV VITE_GAME_HUB_URL=$VITE_GAME_HUB_URL
+RUN pnpm build
+
+FROM nginx:1.27-alpine AS final
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80

--- a/src/ClientApp/nginx.conf
+++ b/src/ClientApp/nginx.conf
@@ -1,0 +1,32 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /api/ {
+        proxy_pass http://web-api:8080/;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /game-runtime-hub {
+        proxy_pass http://web-api:8080/game-runtime-hub;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/src/ClientApp/src/features/game/api/gameHub.ts
+++ b/src/ClientApp/src/features/game/api/gameHub.ts
@@ -1,4 +1,5 @@
 import * as signalR from "@microsoft/signalr";
+import { gameHubUrl } from "@/shared/config/api";
 import { useGameRuntimeStore } from "../state/game.runtime.store";
 
 class GameHubConnection {
@@ -27,7 +28,7 @@ class GameHubConnection {
     }
 
     this.connection = new signalR.HubConnectionBuilder()
-      .withUrl(`/game-runtime-hub`)
+      .withUrl(gameHubUrl())
       .withAutomaticReconnect()
       .build();
 

--- a/src/ClientApp/src/shared/api/loadActionAssets.ts
+++ b/src/ClientApp/src/shared/api/loadActionAssets.ts
@@ -1,4 +1,5 @@
 import { Texture, Rectangle, ImageSource } from "pixi.js"
+import { apiUrl } from "@/shared/config/api"
 import type { ActionAssetDto } from "@/shared/types/action"
 
 /**
@@ -28,7 +29,7 @@ export async function loadActionAssets(actionAssets: ActionAssetDto[]) {
  */
 export async function loadTexturesFromUrl(url: string, frameCount: number): Promise<Texture[]> {
   try {
-    const res = await fetch(`${import.meta.env.VITE_API_URL}/assets/${url}`);
+    const res = await fetch(apiUrl(`/assets/${url}`));
     if (!res.ok) throw new Error(`Ошибка при загрузке ${url}`);
 
     const blob = await res.blob();
@@ -55,7 +56,7 @@ export async function loadTexturesFromUrl(url: string, frameCount: number): Prom
  */
 export async function loadTextureFromUrl(url: string): Promise<Texture | null> {
   try {
-    const res = await fetch(`${import.meta.env.VITE_API_URL}/assets/${url}`)
+    const res = await fetch(apiUrl(`/assets/${url}`))
     if (!res.ok) throw new Error(`Ошибка при загрузке ${url}`)
 
     const blob = await res.blob()
@@ -70,5 +71,5 @@ export async function loadTextureFromUrl(url: string): Promise<Texture | null> {
 
 export function getAssetUrl(assetKey?: string | null) {
   if (!assetKey) return null
-  return `${import.meta.env.VITE_API_URL}/assets/${assetKey}`
+  return apiUrl(`/assets/${assetKey}`)
 }

--- a/src/ClientApp/src/shared/config/api.ts
+++ b/src/ClientApp/src/shared/config/api.ts
@@ -1,0 +1,31 @@
+const apiBaseUrl = normalizeBaseUrl(import.meta.env.VITE_API_URL ?? "")
+const configuredGameHubUrl = normalizeBaseUrl(import.meta.env.VITE_GAME_HUB_URL ?? "")
+
+export function apiUrl(path: string): string {
+  return joinUrl(apiBaseUrl, path)
+}
+
+export function gameHubUrl(): string {
+  if (configuredGameHubUrl) {
+    return configuredGameHubUrl
+  }
+
+  if (isAbsoluteUrl(apiBaseUrl)) {
+    return joinUrl(apiBaseUrl, "/game-runtime-hub")
+  }
+
+  return "/game-runtime-hub"
+}
+
+function normalizeBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "")
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`
+  return `${baseUrl}${normalizedPath}`
+}
+
+function isAbsoluteUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value)
+}

--- a/src/ClientApp/src/shared/hooks/useAsset.ts
+++ b/src/ClientApp/src/shared/hooks/useAsset.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query"
+import { apiUrl } from "@/shared/config/api"
 
 export function useAssetBlob(assetKey: string | undefined) {
   return useQuery<Blob, Error>({
     queryKey: ["asset", assetKey],
     queryFn: async () => {
-      const res = await fetch(`${import.meta.env.VITE_API_URL}/assets/${assetKey}`)
+      const res = await fetch(apiUrl(`/assets/${assetKey}`))
       if (!res.ok) {
         let msg = "Ошибка при загрузке ассета"
         try {

--- a/src/ClientApp/src/shared/lib/apiFetch.ts
+++ b/src/ClientApp/src/shared/lib/apiFetch.ts
@@ -1,3 +1,4 @@
+import { apiUrl } from "@/shared/config/api"
 import { clearAuth, getAccessToken, getRefreshToken, saveAuthTokens } from "./auth"
 
 export type ApiErrorItem = {
@@ -45,11 +46,10 @@ export class ApiException extends Error {
  * Универсальная функция для запросов к API.
  */
 export async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const baseUrl = import.meta.env.VITE_API_URL
   let accessToken = getAccessToken()
 
   const makeRequest = async (token: string | null) =>
-    fetch(`${baseUrl}${path}`, {
+    fetch(apiUrl(path), {
       ...options,
       headers: {
         "Content-Type": "application/json",
@@ -105,7 +105,7 @@ async function refreshAccessToken(): Promise<string> {
   if (!refreshToken)
     throw new Error("Нет refresh-токена")
 
-  const res = await fetch(`${import.meta.env.VITE_API_URL}/users/refresh-token`, {
+  const res = await fetch(apiUrl("/users/refresh-token"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ refreshToken }),

--- a/src/ClientApp/src/vite-env.d.ts
+++ b/src/ClientApp/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL?: string
+  readonly VITE_GAME_HUB_URL?: string
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv
+}

--- a/src/Web.Api/Dockerfile
+++ b/src/Web.Api/Dockerfile
@@ -1,35 +1,37 @@
-# See https://aka.ms/customizecontainer to learn how to customize your debug container and how Visual Studio uses this Dockerfile to build your images for faster debugging.
+# Production image for ByteFight Web API.
 
-# This stage is used when running from VS in fast mode (Default for Debug configuration)
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 USER $APP_UID
 WORKDIR /app
 EXPOSE 8080
-EXPOSE 8081
 
-
-# This stage is used to build the service project
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+
 COPY ["Directory.Packages.props", "."]
 COPY ["Directory.Build.props", "."]
 COPY ["src/Web.Api/Web.Api.csproj", "src/Web.Api/"]
+COPY ["src/Aspire.ServiceDefaults/Aspire.ServiceDefaults.csproj", "src/Aspire.ServiceDefaults/"]
 COPY ["src/Infrastructure/Infrastructure.csproj", "src/Infrastructure/"]
 COPY ["src/Application/Application.csproj", "src/Application/"]
 COPY ["src/Domain/Domain.csproj", "src/Domain/"]
 COPY ["src/SharedKernel/SharedKernel.csproj", "src/SharedKernel/"]
+COPY ["src/GameRuntime/GameRuntime/GameRuntime.csproj", "src/GameRuntime/GameRuntime/"]
+COPY ["src/GameRuntime/GameRuntime.Logic.User.Api/GameRuntime.Logic.User.Api.csproj", "src/GameRuntime/GameRuntime.Logic.User.Api/"]
+COPY ["src/GameRuntime/GameRuntime.UserCodeApiDocumentation/GameRuntime.UserCodeApiDocumentation.csproj", "src/GameRuntime/GameRuntime.UserCodeApiDocumentation/"]
+COPY ["src/GameRuntime/GameRuntime.UserCodeWorker/GameRuntime.UserCodeWorker.csproj", "src/GameRuntime/GameRuntime.UserCodeWorker/"]
 RUN dotnet restore "./src/Web.Api/Web.Api.csproj"
+RUN dotnet restore "./src/GameRuntime/GameRuntime.UserCodeWorker/GameRuntime.UserCodeWorker.csproj"
+
 COPY . .
 WORKDIR "/src/src/Web.Api"
-RUN dotnet build "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN dotnet build "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build --no-restore
 
-# This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "./Web.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false --no-restore
 
-# This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final
 WORKDIR /app
 COPY --from=publish /app/publish .

--- a/src/Web.Api/Program.cs
+++ b/src/Web.Api/Program.cs
@@ -18,13 +18,26 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+string[] allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
+
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowFrontend", policy =>
     {
-        policy.WithOrigins("http://localhost:5173") // Vite dev server
-              .AllowAnyHeader()
-              .AllowAnyMethod();
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                .AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials();
+        }
+        else
+        {
+            policy.AllowAnyHeader()
+                .AllowAnyMethod()
+                .AllowCredentials()
+                .SetIsOriginAllowed(_ => builder.Environment.IsDevelopment());
+        }
     });
 });
 
@@ -50,9 +63,15 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
     app.MapScalarApiReference();
+}
 
+if (app.Environment.IsDevelopment() || app.Configuration.GetValue<bool>("Database:ApplyMigrations"))
+{
     app.ApplyMigrations();
+}
 
+if (app.Environment.IsDevelopment() || app.Configuration.GetValue<bool>("Database:SeedOnStartup"))
+{
     await app.DatabaseSeed();
 }
 

--- a/src/Web.Api/appsettings.Development.json
+++ b/src/Web.Api/appsettings.Development.json
@@ -24,6 +24,17 @@
     "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
   },
 
+  "Database": {
+    "ApplyMigrations": true,
+    "SeedOnStartup": true
+  },
+
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:5173"
+    ]
+  },
+
   "Jwt": {
     "Secret": "super-duper-secret-value-that-should-be-in-user-secrets",
     "Issuer": "bytefight-api",

--- a/src/Web.Api/appsettings.json
+++ b/src/Web.Api/appsettings.json
@@ -3,10 +3,24 @@
   "ConnectionStrings": {
     "Database": ""
   },
+  "Database": {
+    "ApplyMigrations": false,
+    "SeedOnStartup": false
+  },
+  "Cors": {
+    "AllowedOrigins": []
+  },
   "Jwt": {
     "Secret": "",
     "Issuer": "",
     "Audience": "",
     "ExpirationInMinutes": 0
+  },
+  "Minio": {
+    "Endpoint": "",
+    "AccessKey": "",
+    "SecretKey": "",
+    "BucketName": "assets",
+    "UseSSL": false
   }
 }


### PR DESCRIPTION
### Motivation

- Prepare the repository for production deployment (Portainer / Docker Compose) and make client/server routing and configuration explicit for containerized environments. 
- Centralize API and hub URL handling in the client so builds can target different routing schemes (`/api` prefix vs absolute URLs). 
- Enable configurable migrations/seed behavior and CORS for production vs development. 

### Description

- Added `docker-compose.yml`, `.env.example`, updated `.dockerignore`, and README instructions to support a Portainer/Compose production stack with PostgreSQL, MinIO, Aspire Dashboard, `web-api` and `client` services. 
- Added production `Dockerfile` for `src/ClientApp` and `nginx.conf` to serve the SPA and proxy `/api` and `/game-runtime-hub` to the API; added `src/ClientApp/Dockerfile` build stages and final Nginx image. 
- Introduced `src/ClientApp/src/shared/config/api.ts` and `vite` env typings to normalize `VITE_API_URL`/`VITE_GAME_HUB_URL`, and updated client code (`gameHub.ts`, `loadActionAssets.ts`, `useAsset.ts`, `apiFetch.ts`, etc.) to use `apiUrl()`/`gameHubUrl()`. 
- Updated `src/Web.Api/Dockerfile` to use .NET 10 SDK/runtime and include additional project restores for user-code worker projects, and changed `Program.cs` and `appsettings` to support runtime-controlled migrations/seeding and configurable CORS origins. 
- Adjusted Aspire/launch settings keys and added defaults for production telemetry and MinIO in `appsettings.json`/`appsettings.Development.json`, and expanded README with a new "Подготовка к production и Portainer" section describing deployment steps. 

### Testing

- Ran `dotnet restore ByteFight.sln` and `dotnet build ByteFight.sln` successfully. 
- Executed `dotnet test ByteFight.sln` against the solution test suite and it completed successfully. 
- Built the client with `pnpm build` in `src/ClientApp` and produced the production `dist` output successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa42415d0832c8b39f2f48bfbabb2)